### PR TITLE
Correct motor pins

### DIFF
--- a/arduino/firmware/lib/config/lino_base_config.h
+++ b/arduino/firmware/lib/config/lino_base_config.h
@@ -67,11 +67,11 @@
   #define MOTOR3_IN_B 23
 
   // right side motor pins
-  #define MOTOR2_IN_A 5
-  #define MOTOR2_IN_B 8
+  #define MOTOR2_IN_A 4
+  #define MOTOR2_IN_B 3
 
-  #define MOTOR4_IN_A 4
-  #define MOTOR4_IN_B 2
+  #define MOTOR4_IN_A 5
+  #define MOTOR4_IN_B 6
 #endif
 
 #endif


### PR DESCRIPTION
Only PWM pins support `analogWrite`. These are all the PWM pins: 3, 4, 5, 6, 9, 10, 20, 21, 22, 23.